### PR TITLE
Define clamp function to fix NameError in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,6 +11,11 @@ clock=pygame.time.Clock()
 font=pygame.font.SysFont("consolas",18)
 big_font=pygame.font.SysFont("consolas",40,bold=True)
 
+
+def clamp(value, min_value, max_value):
+    """Return *value* limited to the inclusive range [min_value, max_value]."""
+    return max(min_value, min(max_value, value))
+
 def random_zone(grid):
     radius=random.randint(BOMB_RADIUS_MIN,BOMB_RADIUS_MAX)
     while True:


### PR DESCRIPTION
## Summary
- Add `clamp` helper in `main.py` to constrain values and avoid NameError during runtime

## Testing
- `python -m py_compile main.py`
- `pip install pygame` *(fails: Could not find a version that satisfies the requirement pygame)*

------
https://chatgpt.com/codex/tasks/task_e_68a3cc0943888331bdae50c7cbe2f735