### PR TITLE
Add optional bomb sprite rendering

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,16 @@
 import random, sys, pygame
 from config import *
-from map import build_static_map, build_grid, pos_to_cell, cell_center, nearest_passable_cell, has_line_of_sight
+from map import (
+    build_static_map,
+    build_grid,
+    pos_to_cell,
+    cell_center,
+    nearest_passable_cell,
+    has_line_of_sight,
+)
 from entities import Agent, Bullet, BombState
 from ai import bot_ai, sees
+from render import load_sprites, draw_bomb
 
 pygame.init()
 pygame.display.set_caption("Valor 4v4 BombMode")
@@ -10,6 +18,7 @@ screen=pygame.display.set_mode((VIEW_W, VIEW_H))
 clock=pygame.time.Clock()
 font=pygame.font.SysFont("consolas",18)
 big_font=pygame.font.SysFont("consolas",40,bold=True)
+sprites = load_sprites()
 
 
 def clamp(value, min_value, max_value):
@@ -214,7 +223,7 @@ def main():
             pygame.draw.rect(screen, WALL_DARK, rect.move(-cam_x,-cam_y))
             pygame.draw.rect(screen, WALL_EDGE, rect.move(-cam_x,-cam_y),2)
         pygame.draw.circle(screen,(60,60,60),(bomb.zone_center[0]-cam_x,bomb.zone_center[1]-cam_y),bomb.radius*GRID,2)
-        pygame.draw.circle(screen,(120,120,160),(bomb.zone_center[0]-cam_x,bomb.zone_center[1]-cam_y),8)
+        draw_bomb(screen, bomb, sprites, (cam_x, cam_y))
 
         for a in attackers:
             a.draw(screen,(cam_x,cam_y),font)

--- a/render.py
+++ b/render.py
@@ -1,0 +1,44 @@
+import math
+import pygame
+from config import GRID, BOMB_TIMER_MS
+
+
+def load_sprites():
+    """Load optional sprites used by the game."""
+    sprites = {}
+    try:
+        sprites["bomb"] = pygame.image.load("assets/bomb.png").convert_alpha()
+    except Exception:
+        sprites["bomb"] = None
+    return sprites
+
+
+def draw_bomb(surface, bomb_state, sprites, cam=(0, 0)):
+    """Draw the bomb icon or a fallback circle at the bomb's zone.
+
+    If a bomb sprite is supplied in ``sprites['bomb']`` it will be blitted
+    centered at the bomb location.  Otherwise a simple circle is used.  When
+    the bomb is planted a small countdown ring indicates the remaining time
+    until detonation.
+    """
+    pos = (
+        int(bomb_state.zone_center[0] - cam[0]),
+        int(bomb_state.zone_center[1] - cam[1]),
+    )
+    icon = sprites.get("bomb")
+    if icon:
+        rect = icon.get_rect(center=pos)
+        surface.blit(icon, rect)
+    else:
+        pygame.draw.circle(surface, (120, 120, 160), pos, 8)
+
+    if bomb_state.state == "planted":
+        elapsed = pygame.time.get_ticks() - bomb_state.planted_time
+        remaining = max(0, BOMB_TIMER_MS - elapsed)
+        frac = remaining / BOMB_TIMER_MS if BOMB_TIMER_MS else 0
+        radius = 16
+        rect = pygame.Rect(0, 0, radius * 2, radius * 2)
+        rect.center = pos
+        start_angle = -math.pi / 2
+        end_angle = start_angle + 2 * math.pi * frac
+        pygame.draw.arc(surface, (255, 60, 60), rect, start_angle, end_angle, 3)


### PR DESCRIPTION
## Summary
- Add `render` module to load optional bomb image and draw bomb with countdown arc
- Integrate sprite rendering into main loop and load assets at startup

## Testing
- `python -m py_compile main.py render.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3e190a9888331bd18a4d301a20209